### PR TITLE
Turn off adaptive resampling to fix the discontinuities in the zoomed…

### DIFF
--- a/geojson.html
+++ b/geojson.html
@@ -18,7 +18,8 @@
 
       tilePath.projection()
           .translate([k / 2 - d[0] * 256, k / 2 - d[1] * 256]) // [0°,0°] in pixels
-          .scale(k / 2 / Math.PI);
+          .scale(k / 2 / Math.PI)
+          .precision(0);
 
       layers.forEach(function(layer){
         var data = json[layer];


### PR DESCRIPTION
… out vector tiles. The discontinuity arises because the lower border of the upper tile gets adaptively resampled and follows a great arc, whereas the upper border of the lower tile does not. Turning off adaptive resampling means that a straight line is drawn for the border of each and they fit together, in the mercator projection. This might lead to artifacts near the polar regions or in other projections, but seems to work fine for most of the world using the mercator projection.

<img width="872" alt="tile_outlines" src="https://cloud.githubusercontent.com/assets/2143629/8798376/292bd860-2fa2-11e5-9ed9-014bb0a0a546.png">
<img width="951" alt="tile_artifacts" src="https://cloud.githubusercontent.com/assets/2143629/8798377/292cad8a-2fa2-11e5-89e2-041e271e603d.png">
