### PR TITLE
set fill to none for water lines

### DIFF
--- a/geojson.html
+++ b/geojson.html
@@ -27,7 +27,7 @@
           svg.selectAll("path")
             .data(data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; return layer + ' ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary){kind += '_boundary';} return layer + ' ' + kind; })
             .attr("d", tilePath);
         }
       });

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           svg.selectAll("path")
             .data(layer_data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; return layer + '-layer ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} return layer + ' ' + kind; })
             .attr("d", tilePath );
         }
       });

--- a/styles.css
+++ b/styles.css
@@ -61,13 +61,14 @@ a.zoom:last-child {
 }
 
 .tile .water, .tile .ocean { fill: #9DD9D2; stroke: #9DD9D2; }
-.tile .water-layer, .tile .river, .tile .stream, .tile .canal { stroke: #9DD9D2; stroke-width: 1.5px;}
 .tile .riverbank { fill: #9DD9D2; }
+.tile .water-layer, .tile .river, .tile .stream, .tile .canal { fill: none; stroke: #9DD9D2; stroke-width: 1.5px; }
+.tile .water_boundary, .tile .ocean_boundary, .tile .riverbank_boundary { fill: none; stroke: #93cbc4; stroke-width: 0.5px; }
 .tile .major_road { stroke: #fb7b7a; stroke-width: 1px; }
 .tile .minor_road { stroke: #999; stroke-width: 0.5px; }
 .tile .highway { stroke: #FA4A48; stroke-width: 1.5px; }
 .tile .buildings-layer { stroke: #987284; stroke-width: 0.15px; }
-.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land {fill: #88D18A;}
+.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land { fill: #88D18A; stroke: #88D18A; }
 .tile .rail { stroke: #503D3F; stroke-width: 0.5px; }
 
 .info {


### PR DESCRIPTION
- River lines were always broken, when we added water polygon boundaries that bug became more obvious. This fixes that.
- But buildings don't seem to draw?
- And parks have the same intermittent drawing problems as before.
