### PR TITLE
fill the water, show the buildings

### DIFF
--- a/geojson.html
+++ b/geojson.html
@@ -27,7 +27,7 @@
           svg.selectAll("path")
             .data(data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; return layer + ' ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary){kind += '_boundary';} return layer + ' ' + kind; })
             .attr("d", tilePath);
         }
       });

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           svg.selectAll("path")
             .data(layer_data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} if(d.properties.label_position=='yes'){kind += '_label_position';} return layer + '-layer ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} if(d.properties.label_placement=='yes'){kind += '_label_placement';} return layer + '-layer ' + kind; })
             .attr("d", tilePath );
         }
       });

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           svg.selectAll("path")
             .data(layer_data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} return layer + ' ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} if(d.properties.label_position=='yes'){kind += '_label_position';} return layer + '-layer ' + kind; })
             .attr("d", tilePath );
         }
       });

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           svg.selectAll("path")
             .data(layer_data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; return layer + '-layer ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} return layer + ' ' + kind; })
             .attr("d", tilePath );
         }
       });

--- a/scripts.js
+++ b/scripts.js
@@ -7,7 +7,7 @@ var tile = d3.geo.tile()
     .size([width, height]);
 
 var projection = d3.geo.mercator()
-    .scale((1 << 21) / 2 / Math.PI)
+    .scale((1 << 19) / 2 / Math.PI)
     .translate([-width / 2, -height / 2]); // just temporary
 
 var tileProjection = d3.geo.mercator();

--- a/scripts.js
+++ b/scripts.js
@@ -7,7 +7,7 @@ var tile = d3.geo.tile()
     .size([width, height]);
 
 var projection = d3.geo.mercator()
-    .scale((1 << 19) / 2 / Math.PI)
+    .scale((1 << 20) / 2 / Math.PI)
     .translate([-width / 2, -height / 2]); // just temporary
 
 var tileProjection = d3.geo.mercator();

--- a/scripts.js
+++ b/scripts.js
@@ -7,7 +7,7 @@ var tile = d3.geo.tile()
     .size([width, height]);
 
 var projection = d3.geo.mercator()
-    .scale((1 << 21) / 2 / Math.PI)
+    .scale((1 << 21) / 2 / Math.PI) // change scale here, 21 is about z13
     .translate([-width / 2, -height / 2]); // just temporary
 
 var tileProjection = d3.geo.mercator();
@@ -17,7 +17,7 @@ var tilePath = d3.geo.path()
 
 var zoom = d3.behavior.zoom()
     .scale(projection.scale() * 2 * Math.PI)
-    .scaleExtent([1 << 12, 1 << 25])
+    .scaleExtent([1 << 12, 1 << 25]) // 12 to 25 is roughly z4-z5 to z17
     //sf - 37.7524/-122.4407
     .translate(projection([-122.4407, 37.7524]).map(function(x) { return -x; }))
     .on("zoom", zoomed);

--- a/scripts.js
+++ b/scripts.js
@@ -7,7 +7,7 @@ var tile = d3.geo.tile()
     .size([width, height]);
 
 var projection = d3.geo.mercator()
-    .scale((1 << 20) / 2 / Math.PI)
+    .scale((1 << 21) / 2 / Math.PI)
     .translate([-width / 2, -height / 2]); // just temporary
 
 var tileProjection = d3.geo.mercator();

--- a/styles.css
+++ b/styles.css
@@ -61,13 +61,14 @@ a.zoom:last-child {
 }
 
 .tile .water, .tile .ocean { fill: #9DD9D2; stroke: #9DD9D2; }
-.tile .water-layer, .tile .river, .tile .stream, .tile .canal { stroke: #9DD9D2; stroke-width: 1.5px;}
 .tile .riverbank { fill: #9DD9D2; }
+.tile .water-layer, .tile .river, .tile .stream, .tile .canal { fill: none; stroke: #9DD9D2; stroke-width: 1.5px; }
+.tile .water_boundary, .tile .ocean_boundary, .tile .riverbank_boundary { fill: none; stroke: #93cbc4; stroke-width: 0.5px; }
 .tile .major_road { stroke: #fb7b7a; stroke-width: 1px; }
 .tile .minor_road { stroke: #999; stroke-width: 0.5px; }
 .tile .highway { stroke: #FA4A48; stroke-width: 1.5px; }
 .tile .buildings-layer { stroke: #987284; stroke-width: 0.15px; }
-.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land {fill: #88D18A;}
+.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land { fill: #88D18A; stroke: #88D18A; }
 .tile .rail { stroke: #503D3F; stroke-width: 0.5px; }
 
 .info {

--- a/styles.css
+++ b/styles.css
@@ -60,15 +60,15 @@ a.zoom:last-child {
   stroke-linecap: round;
 }
 
-.tile .water, .tile .ocean { fill: #9DD9D2; stroke: #9DD9D2; }
-.tile .riverbank { fill: #9DD9D2; }
 .tile .water-layer, .tile .river, .tile .stream, .tile .canal { fill: none; stroke: #9DD9D2; stroke-width: 1.5px; }
+.tile .water, .tile .ocean { fill: #9DD9D2; }
+.tile .riverbank { fill: #9DD9D2; }
 .tile .water_boundary, .tile .ocean_boundary, .tile .riverbank_boundary { fill: none; stroke: #93cbc4; stroke-width: 0.5px; }
 .tile .major_road { stroke: #fb7b7a; stroke-width: 1px; }
 .tile .minor_road { stroke: #999; stroke-width: 0.5px; }
 .tile .highway { stroke: #FA4A48; stroke-width: 1.5px; }
 .tile .buildings-layer { stroke: #987284; stroke-width: 0.15px; }
-.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land { fill: #88D18A; stroke: #88D18A; }
+.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected_land { fill: #88D18A; stroke: #88D18A; stroke-width: 0.5px; }
 .tile .rail { stroke: #503D3F; stroke-width: 0.5px; }
 
 .info {


### PR DESCRIPTION
- Add back the `-layer` append when constructing classes out of kind properties (thus allowing buildings to render again)
- Add `layer_position` postfix (like was done earlier for `_boundary` as those are points)
- Turns out `protected-land` was never working, but `protected_land` is a thing
- Reorder `water-layer` CSS to simplify fill and stroking of classes and leverage order of operations
- Rebased to pick up some old commits (which mostly seem to be comments not code)
