### PR TITLE
GH-PAGES: fill the water, show the buildings

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           svg.selectAll("path")
             .data(layer_data.features.sort(function(a, b) { return a.properties.sort_key ? a.properties.sort_key - b.properties.sort_key : 0 }))
           .enter().append("path")
-            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} return layer + ' ' + kind; })
+            .attr("class", function(d) { var kind = d.properties.kind || ''; if(d.properties.boundary=='yes'){kind += '_boundary';} if(d.properties.label_position=='yes'){kind += '_label_position';} return layer + '-layer ' + kind; })
             .attr("d", tilePath );
         }
       });

--- a/styles.css
+++ b/styles.css
@@ -60,15 +60,15 @@ a.zoom:last-child {
   stroke-linecap: round;
 }
 
-.tile .water, .tile .ocean { fill: #9DD9D2; stroke: #9DD9D2; }
-.tile .riverbank { fill: #9DD9D2; }
 .tile .water-layer, .tile .river, .tile .stream, .tile .canal { fill: none; stroke: #9DD9D2; stroke-width: 1.5px; }
+.tile .water, .tile .ocean { fill: #9DD9D2; }
+.tile .riverbank { fill: #9DD9D2; }
 .tile .water_boundary, .tile .ocean_boundary, .tile .riverbank_boundary { fill: none; stroke: #93cbc4; stroke-width: 0.5px; }
 .tile .major_road { stroke: #fb7b7a; stroke-width: 1px; }
 .tile .minor_road { stroke: #999; stroke-width: 0.5px; }
 .tile .highway { stroke: #FA4A48; stroke-width: 1.5px; }
 .tile .buildings-layer { stroke: #987284; stroke-width: 0.15px; }
-.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected-land { fill: #88D18A; stroke: #88D18A; }
+.tile .park, .tile .nature_reserve, .tile .wood, .tile .protected_land { fill: #88D18A; stroke: #88D18A; stroke-width: 0.5px; }
 .tile .rail { stroke: #503D3F; stroke-width: 0.5px; }
 
 .info {


### PR DESCRIPTION
- Add back the `-layer` append when constructing classes out of kind properties (thus allowing buildings to render again)
- Add `layer_position` postfix (like was done earlier for `_boundary` as those are points)
- Turns out `protected-land` was never working, but `protected_land` is a thing
- Reorder `water-layer` CSS to simplify fill and stroking of classes and leverage order of operations
- Rebased to pick up some old commits (which mostly seem to be comments not code)
