### PR TITLE
Update link to topojson.js

### DIFF
--- a/topojson.html
+++ b/topojson.html
@@ -5,7 +5,7 @@
 <body>
 <script src="d3.v3.min.js"></script>
 <script src="d3.geo.tile.v0.min.js"></script>
-<script src="https://cdn.rawgit.com/mbostock/topojson/master/topojson.js"></script>
+<script src="https://cdn.rawgit.com/mbostock/topojson/3ed6ee9e04d4/topojson.js"></script>
 <script src='//s3.amazonaws.com/assets-staging.mapzen.com/ui/components/bug/bug.min.js'></script>
 <script type='text/javascript'>
   window.bugTitle = 'Map using d3 and topojson';


### PR DESCRIPTION
The `mbostock/topojson` repository is no longer hosting topojson.js on master. This proposes linking to the last SHA of its existence. See discussion https://github.com/mapzen/blog/issues/698
